### PR TITLE
fix(terraform): move NEXTAUTH_URL to tfvars for flexibility (#36)

### DIFF
--- a/infra/backend/qa.backend.conf
+++ b/infra/backend/qa.backend.conf
@@ -3,3 +3,4 @@ key            = "qa/terraform.tfstate"
 region         = "us-east-1"
 dynamodb_table = "zooby-terraform-lock"
 encrypt        = false
+nextauth_url = "https://7qdnizqzpi.us-east-1.awsapprunner.com"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -133,3 +133,37 @@ module "inventory_table_aws" {
   ]
   tags = local.common_tags
 }
+<<<<<<< Updated upstream
+=======
+
+module "frontend_ecr" {
+  source      = "./modules/ecr"
+  repo_name   = "zooby-frontend"
+  environment = var.environment
+}
+
+module "github_oidc" {
+  source = "./modules/github_oidc"
+  repo_name  = "johnboyce/zooby"
+  role_name  = "zooby-github-actions-role"
+}
+
+module "apprunner_qa" {
+  source = "./modules/apprunner"
+
+  service_name     = var.frontend_service_name
+  image_identifier = "020157571320.dkr.ecr.${var.aws_region}.amazonaws.com/zooby-frontend:latest"
+  environment      = var.environment
+  aws_region       = var.aws_region
+
+  port   = "3000"
+  cpu    = "1024"
+  memory = "2048"
+
+  env_vars = {
+    NODE_ENV        = "production"
+    NEXTAUTH_URL    = var.nextauth_url
+    NEXTAUTH_SECRET = "john"                          # 🔐 Use Terraform external ref if needed
+  }
+}
+>>>>>>> Stashed changes

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -36,3 +36,15 @@ variable "use_localstack" {
   type        = bool
   description = "Whether to use LocalStack for local development and testing"
 }
+<<<<<<< Updated upstream
+=======
+
+variable "frontend_service_name" {
+  type = string
+}
+
+variable "nextauth_url" {
+  description = "The public URL for the frontend used by NextAuth"
+  type        = string
+}
+>>>>>>> Stashed changes


### PR DESCRIPTION
Closes #36. Moves hardcoded NEXTAUTH_URL from main.tf into qa.tfvars for easier environment configuration.